### PR TITLE
Fixed issue with dropping cards from pile onto the same pile

### DIFF
--- a/src/reducers/GameReducer.js
+++ b/src/reducers/GameReducer.js
@@ -60,6 +60,14 @@ function movingMultipleCardsFromPileToPile(where, cards) {
 
 function moveCards(state, action) {
     let { cards, where } = action.payload;
+
+    if( (where.from[0] == Places.PILE) && 
+        (where.to[0] == Places.PILE) && 
+        (where.from[1] == where.to[1])
+    ){
+        return state;
+    }
+    
     let source = state.getIn(where.from)
     if (movingMultipleCardsFromPileToPile(where, cards)) {
         cards = source.slice(first(cards).index);

--- a/test/reducers/GameReducer_test.js
+++ b/test/reducers/GameReducer_test.js
@@ -59,6 +59,13 @@ describe('MOVE_CARD', () => {
         ).toExclude(TestActions.PILE_TO_PILE.payload.cards[0])
     });
 
+    it('should handle from PILE to the same PILE', () => {
+        const newState = getNewGame(TestActions.PILE_TO_SAME_PILE);
+        const expectedState = initialState.game.toJS();
+
+        expect(newState).toEqual(expectedState);
+    });
+
     it('should handle from PILE to PILE, multiple cards');
 
     it('should handle from FOUNDATION to PILE', () => {

--- a/test/reducers/TestActions.js
+++ b/test/reducers/TestActions.js
@@ -33,6 +33,23 @@ export default {
         }
     },
 
+    PILE_TO_SAME_PILE: {
+        type: 'MOVE_CARD',
+        payload: {
+            cards: [
+                {
+                    suit: 'SPADES',
+                    rank: '2',
+                    where: ['PILE', 3],
+                    upturned: true,
+                    isLast: true,
+                    index: 4
+                }
+            ],
+            where: { from: ['PILE', 3], to: ['PILE', 3] }
+        }
+    },
+
     FOUNDATION_TO_PILE: {
         type: 'MOVE_CARD',
         payload: {


### PR DESCRIPTION
The simplest way to reproduce the bug is to drop the king onto itself, resulting in the card being removed from the deck. This may be the cause for [Missing card #3](https://github.com/gcedo/react-solitaire/issues/3).

I've made a simple fix in the `moveCards` reducer by checking whether the card is being moved onto the same pile, and a gameReducer test.
