### PR TITLE
Improved alignment and appearance of card elements

### DIFF
--- a/src/components/display/Card.jsx
+++ b/src/components/display/Card.jsx
@@ -17,7 +17,7 @@ const Card =
         boxShadow: Shadows.Level1,
         boxSizing: 'border-box',
         color: Colors[suit],
-        fontFamily: 'Helvetica',
+        fontFamily: 'Arial',
         padding: 4,
         position: 'relative',
         width: Dimensions.Card.width,

--- a/src/components/display/ReactSymbol.jsx
+++ b/src/components/display/ReactSymbol.jsx
@@ -4,12 +4,13 @@ import { Colors } from '../../constants';
 const ReactSymbol = ({ color }) => {
     return (
         <div style={{
-            fontSize: 150,
+            fontSize: 120,
             position: 'absolute',
-            top: -4,
-            left: 17,
-            color: color,
-            bottom: 0
+            top: '6%',
+            left: 0,
+            right: 0,
+            textAlign: 'center',
+            color: color
         }}>
             ⚛
         </div>

--- a/src/components/display/ReactSymbol.jsx
+++ b/src/components/display/ReactSymbol.jsx
@@ -5,6 +5,7 @@ const ReactSymbol = ({ color }) => {
     return (
         <div style={{
             fontSize: 120,
+            fontFamily: "Apple Symbols",
             position: 'absolute',
             top: '6%',
             left: 0,

--- a/src/components/display/SuitAndRank.jsx
+++ b/src/components/display/SuitAndRank.jsx
@@ -7,16 +7,11 @@ const SuitAndRank = ({ suit, rank, position }) => {
             ...position,
             display: 'inline-block',
             position: 'absolute',
+            textAlign: 'center',
             transform: ('bottom' in position) ? 'rotate(180deg)' : null
         }}>
             <div>{rank}</div>
-            <div style={{
-                position: 'relative',
-                top: -5,
-                textAlign: 'center'
-            }}>
-                {Suits[suit]}
-            </div>
+            <div style={{ position: 'relative', top: -5 }}>{Suits[suit]}</div>
         </div>
     );
 }


### PR DESCRIPTION
Positioning and appearance of card elements (rank, suit and react logo) were inconsistent across browsers and particularly noticeable in webkit-based page renderers.

I have made some style adjustments to improve the appearance and consistency (tested on OS X in Safari, Chrome and Firefox).

Before:

![elements-misaligned-in-safari](https://cloud.githubusercontent.com/assets/451178/12638334/52ef70fe-c56a-11e5-97f0-27ec77e27621.png)

After:

![safari-view-after-alignment](https://cloud.githubusercontent.com/assets/451178/12638336/5799511a-c56a-11e5-963f-46547be1caa6.png)
