### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node devServer.js",
     "build:webpack": "NODE_ENV=production webpack --config webpack.config.prod.js",
-    "test": "mocha --compilers js:babel-register --recursive",
+    "test": "mocha --require babel-core/register --recursive",
     "test:watch": "npm test -- --watch",
     "coverage": "cross-env NODE_ENV=test nyc -- npm test",
     "coveralls": "cross-env NODE_ENV=test nyc report --reporter=lcov && coveralls < ./coverage/lcov.info && rm -rf ./coverage"

--- a/package.json
+++ b/package.json
@@ -21,12 +21,13 @@
   "dependencies": {
     "immutable": "^3.7.5",
     "lodash": "^3.10.1",
-    "react": "^0.14.0-rc1",
+    "prop-types": "^15.6.0",
+    "react": "^16.2.0",
     "react-dnd": "^2.0.2",
     "react-dnd-html5-backend": "^2.0.0",
-    "react-dom": "^0.14.0-rc1",
-    "react-prefixer": "^1.1.4",
-    "react-redux": "^3.1.0",
+    "react-dom": "^16.2.0",
+    "react-prefixer": "^2.0.0",
+    "react-redux": "^5.0.6",
     "redux": "^3.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "redbox-react": "^1.0.1",
     "redux-devtools": "^3.4.1",
     "redux-devtools-dock-monitor": "^1.1.3",
-    "redux-slider-monitor": "^1.0.7",
+    "redux-slider-monitor": "^2.0.0-1",
     "rimraf": "^2.4.3",
     "unexpected": "^10.0.2",
     "unexpected-react-shallow": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "express": "^4.13.3",
     "mocha": "^5.0.0",
     "nyc": "^11.4.1",
-    "react-addons-test-utils": "^0.14.1",
+    "react-test-renderer": "^16.2.0",
     "react-transform-catch-errors": "^1.0.0",
     "react-transform-hmr": "^1.0.0",
     "redbox-react": "^1.0.1",

--- a/src/components/controller/DraggableCard.jsx
+++ b/src/components/controller/DraggableCard.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes as T } from 'react';
+import React from 'react';
+import T from 'prop-types';
 import Card from '../display/Card.jsx';
 import { Ranks, Suits, RanksValues, Places, Colors } from '../../constants';
 import { DragSource, DropTarget } from 'react-dnd';

--- a/src/components/controller/SmartDeck.jsx
+++ b/src/components/controller/SmartDeck.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes as T } from 'react';
+import React from 'react';
+import T from 'prop-types';
 import Card from '../display/Card.jsx';
 import { Suits, Ranks } from '../../constants';
 import UpturnedCard from '../display/UpturnedCard.jsx';

--- a/src/components/controller/SmartFoundation.jsx
+++ b/src/components/controller/SmartFoundation.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes as T } from 'react';
+import React from 'react';
+import T from 'prop-types';
 import Foundation from '../display/Foundation.jsx';
 import ActionCreators, { Directions } from '../../actions';
 import DraggableCard from './DraggableCard.jsx';

--- a/src/components/controller/SmartPile.jsx
+++ b/src/components/controller/SmartPile.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes as T } from 'react';
+import React from 'react';
+import T from 'prop-types';
 import Pile from '../display/Pile.jsx';
 import { List } from 'immutable';
 import Card from '../display/Card.jsx';

--- a/src/components/display/Card.jsx
+++ b/src/components/display/Card.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes as T } from 'react';
+import React from 'react';
+import T from 'prop-types';
 import Overlay from './Overlay.jsx';
 import SuitAndRank from './SuitAndRank.jsx';
 import SuitSymbol from './SuitSymbol.jsx';

--- a/src/components/display/Deck.jsx
+++ b/src/components/display/Deck.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes as T } from 'react';
+import React from 'react';
+import T from 'prop-types';
 
 const Deck = ({ onClick, children }) => {
     return (

--- a/src/components/display/Pile.jsx
+++ b/src/components/display/Pile.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes as T } from 'react';
+import React from 'react';
+import T from 'prop-types';
 import RankSymbol from './RankSymbol.jsx';
 import { Colors, Dimensions, CardsLayouts } from '../../constants';
 

--- a/src/components/display/RankSymbol.jsx
+++ b/src/components/display/RankSymbol.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes as T } from 'react';
+import React from 'react';
+import T from 'prop-types';
 
 const RankSymbol = ({ symbol, style }) => {
     return (

--- a/src/components/display/ReactSymbol.jsx
+++ b/src/components/display/ReactSymbol.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes as T } from 'react';
+import React from 'react';
+import T from 'prop-types';
 import { Colors } from '../../constants';
 
 const ReactSymbol = ({ color }) => {

--- a/src/components/display/SuitAndRank.jsx
+++ b/src/components/display/SuitAndRank.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes as T } from 'react';
+import React from 'react';
+import T from 'prop-types';
 import { Suits, Ranks } from '../../constants';
 
 const SuitAndRank = ({ suit, rank, position }) => {

--- a/test/components/display/ReactSymbol_test.js
+++ b/test/components/display/ReactSymbol_test.js
@@ -1,17 +1,17 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
 import ReactSymbol from '../../../src/components/display/ReactSymbol.jsx';
+import ShallowRenderer from 'react-test-renderer/shallow';
 import unexpected from 'unexpected';
 import unexpectedReactShallow from 'unexpected-react-shallow';
 
 const expect = unexpected.clone().installPlugin(unexpectedReactShallow);
-const renderer = TestUtils.createRenderer();
+const renderer = new ShallowRenderer();
 
 describe('ReactSymbol', () => {
     it('should render properly', function () {
         renderer.render(<ReactSymbol />);
 
-        expect(renderer, 'to have rendered',
+        expect(renderer.getRenderOutput(), 'to have rendered',
             <div>⚛</div>
         )
     });


### PR DESCRIPTION
- Update react and its related packages
    - As `PropTypes` has been extracted into `prop-types` package, add `prop-types` to dependencies and update `import` statements in JSX files.
    - Update `redux-slider-monitor` as the older version imports `PropTypes` from `react` package and raises exceptions.
    - Replace `react-addons-test-utils` ([deprecated](https://www.npmjs.com/package/react-addons-test-utils)) with `react-test-renderer/shallow`
- Update mocha option (It should have been updated in #13.)